### PR TITLE
Fix grpc port conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+*.egg-info

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,3 @@ jsonschema==4.17.0
 lightkube==0.11.0
 lightkube-models==1.24.1.4
 tenacity==8.1.0
-<<<<<<< Updated upstream
-ops-scenario
-=======
->>>>>>> Stashed changes
-pydantic

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,7 @@ from tempo import Tempo
 logger = logging.getLogger(__name__)
 
 
-@trace_charm(tempo_endpoint="_tempo_otlp_grpc_endpoint", service_name="TempoCharm")
+@trace_charm(tempo_endpoint="_tempo_otlp_grpc_endpoint")
 class TempoCharm(CharmBase):
     """Charmed Operator for Tempo; a distributed tracing backend."""
 

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -12,9 +12,14 @@ class Tempo:
     wal_path = "/etc/tempo_wal"
     log_path = "/var/log/tempo.log"
 
-    def __init__(self, port: int = 3200, local_host: str = "0.0.0.0"):
+    def __init__(self, port: int = 3200,
+                 grpc_listen_port: int = 9096, local_host: str = "0.0.0.0"):
         self.tempo_port = port
 
+        # default grpc listen port is 9095, but that conflicts with promtail.
+        self.grpc_listen_port = grpc_listen_port
+
+        # ports source: https://github.com/grafana/tempo/blob/main/example/docker-compose/local/docker-compose.yaml
         # todo make configurable?
         self.otlp_grpc_port = 4317
         self.otlp_http_port = 4318
@@ -49,7 +54,10 @@ class Tempo:
             {
                 "auth_enabled": False,
                 "search_enabled": True,
-                "server": {"http_listen_port": self.tempo_port},
+                "server": {
+                    "http_listen_port": self.tempo_port,
+                    "grpc_listen_port": self.grpc_listen_port,
+                },
                 # this configuration will listen on all ports and protocols that tempo is capable of.
                 # the receives all come from the OpenTelemetry collector.  more configuration information can
                 # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/overlord/receiver

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,6 @@ deps =
     pytest
     juju
     pytest-operator
-    tenacity
     requests
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
promtail tries to use port 9095 for its grpc listen server, but tempo has already snatched it.
This PR sets a different grpc listen port for Tempo.