### PR TITLE
Endpoint removed handling

### DIFF
--- a/lib/charms/tempo_k8s/v0/charm_instrumentation.py
+++ b/lib/charms/tempo_k8s/v0/charm_instrumentation.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-grpc==1.17.0"]
 

--- a/lib/charms/tempo_k8s/v0/charm_instrumentation.py
+++ b/lib/charms/tempo_k8s/v0/charm_instrumentation.py
@@ -66,15 +66,14 @@ from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import INVALID_SPAN, Tracer
+from opentelemetry.trace import get_current_span as otlp_get_current_span
 from opentelemetry.trace import (
-    INVALID_SPAN,
-    Tracer,
     get_tracer,
     get_tracer_provider,
     set_span_in_context,
     set_tracer_provider,
 )
-from opentelemetry.trace import get_current_span as otlp_get_current_span
 from ops.charm import CharmBase
 from ops.framework import Framework
 

--- a/lib/charms/tempo_k8s/v0/charm_instrumentation.py
+++ b/lib/charms/tempo_k8s/v0/charm_instrumentation.py
@@ -66,14 +66,15 @@ from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.trace import INVALID_SPAN, Tracer
-from opentelemetry.trace import get_current_span as otlp_get_current_span
 from opentelemetry.trace import (
+    INVALID_SPAN,
+    Tracer,
     get_tracer,
     get_tracer_provider,
     set_span_in_context,
     set_tracer_provider,
 )
+from opentelemetry.trace import get_current_span as otlp_get_current_span
 from ops.charm import CharmBase
 from ops.framework import Framework
 

--- a/lib/charms/tempo_k8s/v0/tracing.py
+++ b/lib/charms/tempo_k8s/v0/tracing.py
@@ -470,11 +470,11 @@ class TracingEndpointProvider(Object):
         """Notify the providers that there is new endpoint information available."""
         relation = event.relation
         if not self.is_ready(relation):
+            self.on.endpoint_removed.emit(relation)  # type: ignore
             return
 
         data = TracingRequirerAppData.load(relation.data[relation.app])
-        if data:
-            self.on.endpoint_changed.emit(relation, data.host, [i.dict() for i in data.ingesters])  # type: ignore
+        self.on.endpoint_changed.emit(relation, data.host, [i.dict() for i in data.ingesters])  # type: ignore
 
     def _on_tracing_relation_broken(self, event: RelationBrokenEvent):
         """Notify the providers that the endpoint is broken."""

--- a/lib/charms/tempo_k8s/v0/tracing.py
+++ b/lib/charms/tempo_k8s/v0/tracing.py
@@ -77,7 +77,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["pydantic<2.0"]
 
@@ -435,6 +435,11 @@ class TracingEndpointProvider(Object):
             return False
         if not relation.app:
             logger.error(f"{relation} event received but there is no relation.app")
+            return False
+        try:
+            TracingRequirerAppData.load(relation.data[relation.app])
+        except (json.JSONDecodeError, pydantic.ValidationError):
+            logger.info(f"failed validating relation data for {relation}")
             return False
         return True
 

--- a/lib/charms/tempo_k8s/v0/tracing.py
+++ b/lib/charms/tempo_k8s/v0/tracing.py
@@ -105,6 +105,10 @@ class DataValidationError(TracingError):
     """Raised when data validation fails on IPU relation data."""
 
 
+class AmbiguousRelationUsageError(TracingError):
+    """Raised when one wrongly assumes that there can only be one relation on an endpoint."""
+
+
 # todo: use fully-encoded json fields like Traefik does. MUCH neater
 class DatabagModel(BaseModel):
     """Base databag model."""
@@ -431,6 +435,9 @@ class TracingEndpointProvider(Object):
         )
 
         super().__init__(charm, relation_name)
+
+        self._is_single_endpoint = charm.meta.relations[relation_name].limit == 1
+
         self._charm = charm
         self._relation_name = relation_name
 
@@ -439,22 +446,32 @@ class TracingEndpointProvider(Object):
         self.framework.observe(events.relation_broken, self._on_tracing_relation_broken)
 
     @property
-    def relation(self) -> Relation:
-        """The tracing relation associated with this endpoint.
+    def relations(self) -> List[Relation]:
+        """The tracing relations associated with this endpoint."""
+        return self._charm.model.relations[self._relation_name]
 
-        Assumes tracing has limit 1.
-        """
-        return self._charm.model.get_relation(self._relation_name)
+    @property
+    def _relation(self) -> Relation:
+        """If this wraps a single endpoint, the relation bound to it, if any."""
+        if not self._is_single_endpoint:
+            objname = type(self).__name__
+            raise AmbiguousRelationUsageError(
+                f"This {objname} wraps a {self._relation_name} endpoint that has "
+                "limit != 1. We can't determine what relation, of the possibly many, you are "
+                f"talking about. Please pass a relation instance while calling {objname}, "
+                "or set limit=1 in the charm metadata."
+            )
+        relations = self.relations
+        return relations[0] if relations else None
 
     def is_ready(self, relation: Optional[Relation] = None):
         """Is this endpoint ready?"""
-        relation = relation or self.relation
-
+        relation = relation or self._relation
         if not relation:
-            logger.error("no relation")
+            logger.error(f"no relation on {self._relation_name}: tracing not ready")
             return False
         if relation.data is None:
-            logger.error("relation data is None")
+            logger.error(f"relation data is None for {relation}")
             return False
         if not relation.app:
             logger.error(f"{relation} event received but there is no relation.app")
@@ -481,16 +498,16 @@ class TracingEndpointProvider(Object):
         relation = event.relation
         self.on.endpoint_removed.emit(relation)
 
-    @property
-    def endpoints(self) -> Optional[TracingRequirerAppData]:
+    def get_all_endpoints(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[TracingRequirerAppData]:
         """Unmarshalled relation data."""
-        relation = self.relation
-        if not self.is_ready(relation):
+        if not self.is_ready(relation or self._relation):
             return
         return TracingRequirerAppData.load(relation.data[relation.app])  # type: ignore
 
-    def _get_ingester(self, protocol: IngesterProtocol):
-        ep = self.endpoints
+    def _get_ingester(self, relation: Relation, protocol: IngesterProtocol):
+        ep = self.get_all_endpoints(relation)
         if not ep:
             return None
         try:
@@ -500,22 +517,18 @@ class TracingEndpointProvider(Object):
             logger.error(f"no ingester found with protocol={protocol!r}")
             return None
 
-    @property
-    def otlp_grpc_endpoint(self) -> Optional[str]:
+    def otlp_grpc_endpoint(self, relation: Optional[Relation] = None) -> Optional[str]:
         """Ingester endpoint for the ``otlp_grpc`` protocol."""
-        return self._get_ingester("otlp_grpc")
+        return self._get_ingester(relation or self._relation, protocol="otlp_grpc")
 
-    @property
-    def otlp_http_endpoint(self) -> Optional[str]:
+    def otlp_http_endpoint(self, relation: Optional[Relation] = None) -> Optional[str]:
         """Ingester endpoint for the ``otlp_http`` protocol."""
-        return self._get_ingester("otlp_http")
+        return self._get_ingester(relation or self._relation, protocol="otlp_http")
 
-    @property
-    def zipkin_endpoint(self) -> Optional[str]:
+    def zipkin_endpoint(self, relation: Optional[Relation] = None) -> Optional[str]:
         """Ingester endpoint for the ``zipkin`` protocol."""
-        return self._get_ingester("zipkin")
+        return self._get_ingester(relation or self._relation, protocol="zipkin")
 
-    @property
-    def tempo_endpoint(self) -> Optional[str]:
+    def tempo_endpoint(self, relation: Optional[Relation] = None) -> Optional[str]:
         """Ingester endpoint for the ``tempo`` protocol."""
-        return self._get_ingester("tempo")
+        return self._get_ingester(relation or self._relation, protocol="tempo")

--- a/lib/charms/tempo_k8s/v0/tracing.py
+++ b/lib/charms/tempo_k8s/v0/tracing.py
@@ -438,7 +438,13 @@ class TracingEndpointProvider(Object):
         self.framework.observe(events.relation_changed, self._on_tracing_relation_changed)
         self.framework.observe(events.relation_broken, self._on_tracing_relation_broken)
 
-    def _is_ready(self, relation: Optional[Relation]):
+    @property
+    def relation(self) -> Relation:
+        return self._charm.model.get_relation(self._relation_name)
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        relation = relation or self.relation
+
         if not relation:
             logger.error("no relation")
             return False
@@ -458,7 +464,7 @@ class TracingEndpointProvider(Object):
     def _on_tracing_relation_changed(self, event):
         """Notify the providers that there is new endpoint information available."""
         relation = event.relation
-        if not self._is_ready(relation):
+        if not self.is_ready(relation):
             return
 
         data = TracingRequirerAppData.load(relation.data[relation.app])
@@ -473,8 +479,8 @@ class TracingEndpointProvider(Object):
     @property
     def endpoints(self) -> Optional[TracingRequirerAppData]:
         """Unmarshalled relation data."""
-        relation = self._charm.model.get_relation(self._relation_name)
-        if not self._is_ready(relation):
+        relation = self.relation
+        if not self.is_ready(relation):
             return
         return TracingRequirerAppData.load(relation.data[relation.app])  # type: ignore
 

--- a/lib/charms/tempo_k8s/v0/tracing.py
+++ b/lib/charms/tempo_k8s/v0/tracing.py
@@ -440,9 +440,14 @@ class TracingEndpointProvider(Object):
 
     @property
     def relation(self) -> Relation:
+        """The tracing relation associated with this endpoint.
+
+        Assumes tracing has limit 1.
+        """
         return self._charm.model.get_relation(self._relation_name)
 
     def is_ready(self, relation: Optional[Relation] = None):
+        """Is this endpoint ready?"""
         relation = relation or self.relation
 
         if not relation:

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,6 @@ from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from ops.charm import CharmBase, WorkloadEvent
 from ops.main import main
 from ops.model import ActiveStatus
-
 from tempo import Tempo
 
 logger = logging.getLogger(__name__)

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,6 +19,7 @@ from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from ops.charm import CharmBase, WorkloadEvent
 from ops.main import main
 from ops.model import ActiveStatus
+
 from tempo import Tempo
 
 logger = logging.getLogger(__name__)

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -3,11 +3,10 @@
 from unittest.mock import patch
 
 import pytest
+from charm import TempoCharm
 from interface_tester import InterfaceTester
 from ops.pebble import Layer
 from scenario.state import Container, State
-
-from charm import TempoCharm
 
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -3,10 +3,11 @@
 from unittest.mock import patch
 
 import pytest
-from charm import TempoCharm
 from interface_tester import InterfaceTester
 from ops.pebble import Layer
 from scenario.state import Container, State
+
+from charm import TempoCharm
 
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
 import pytest
-from charm import TempoCharm
 from scenario import Context
+
+from charm import TempoCharm
 
 
 @pytest.fixture

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,9 +1,8 @@
 from unittest.mock import patch
 
 import pytest
-from scenario import Context
-
 from charm import TempoCharm
+from scenario import Context
 
 
 @pytest.fixture

--- a/tests/scenario/test_charm_instrumentation.py
+++ b/tests/scenario/test_charm_instrumentation.py
@@ -2,12 +2,9 @@ import os
 from unittest.mock import patch
 
 import pytest
-from charms.tempo_k8s.v0.charm_instrumentation import (
-    CHARM_TRACING_ENABLED,
-    get_current_span,
-    trace,
-)
+from charms.tempo_k8s.v0.charm_instrumentation import CHARM_TRACING_ENABLED
 from charms.tempo_k8s.v0.charm_instrumentation import _autoinstrument as autoinstrument
+from charms.tempo_k8s.v0.charm_instrumentation import get_current_span, trace
 from ops import EventBase, EventSource, Framework
 from ops.charm import CharmBase, CharmEvents
 from scenario import Context, State

--- a/tests/scenario/test_charm_instrumentation.py
+++ b/tests/scenario/test_charm_instrumentation.py
@@ -2,9 +2,12 @@ import os
 from unittest.mock import patch
 
 import pytest
-from charms.tempo_k8s.v0.charm_instrumentation import CHARM_TRACING_ENABLED
+from charms.tempo_k8s.v0.charm_instrumentation import (
+    CHARM_TRACING_ENABLED,
+    get_current_span,
+    trace,
+)
 from charms.tempo_k8s.v0.charm_instrumentation import _autoinstrument as autoinstrument
-from charms.tempo_k8s.v0.charm_instrumentation import get_current_span, trace
 from ops import EventBase, EventSource, Framework
 from ops.charm import CharmBase, CharmEvents
 from scenario import Context, State

--- a/tests/scenario/test_tracing_provider.py
+++ b/tests/scenario/test_tracing_provider.py
@@ -50,7 +50,7 @@ def test_requirer_api(context):
         assert charm.tracing.otlp_http_endpoint == f"{host}:4318"
 
         rel = charm.model.get_relation("tracing")
-        assert charm.tracing._is_ready(rel)
+        assert charm.tracing.is_ready(rel)
 
     with _charm_tracing_disabled():
         context.run(tracing.changed_event, state, post_event=post_event)
@@ -92,7 +92,7 @@ def test_invalid_data(context, data):
 
     def post_event(charm: MyCharm):
         rel = charm.model.get_relation("tracing")
-        assert not charm.tracing._is_ready(rel)
+        assert not charm.tracing.is_ready(rel)
 
     with _charm_tracing_disabled():
         context.run(tracing.changed_event, state, post_event=post_event)

--- a/tests/scenario/test_tracing_provider.py
+++ b/tests/scenario/test_tracing_provider.py
@@ -98,9 +98,10 @@ def test_invalid_data(context, data):
         context.run(tracing.changed_event, state, post_event=post_event)
 
     emitted_events = context.emitted_events
-    assert len(emitted_events) == 1  # no endpoint_changed emitted
-    rchanged = emitted_events[0]
+    assert len(emitted_events) == 2
+    rchanged, rremoved = emitted_events
     assert isinstance(rchanged, RelationChangedEvent)
+    assert isinstance(rremoved, EndpointRemovedEvent)
 
 
 def test_broken(context):

--- a/tests/scenario/test_tracing_provider.py
+++ b/tests/scenario/test_tracing_provider.py
@@ -26,7 +26,7 @@ class MyCharm(CharmBase):
 def context():
     return Context(
         charm_type=MyCharm,
-        meta={"name": "jolly", "provides": {"tracing": {"interface": "tracing"}}},
+        meta={"name": "jolly", "provides": {"tracing": {"interface": "tracing", "limit": 1}}},
     )
 
 
@@ -45,9 +45,9 @@ def test_requirer_api(context):
     state = State(leader=True, relations=[tracing])
 
     def post_event(charm: MyCharm):
-        assert charm.tracing.otlp_grpc_endpoint == f"{host}:4317"
-        assert charm.tracing.otlp_http_endpoint == f"{host}:4318"
-        assert charm.tracing.otlp_http_endpoint == f"{host}:4318"
+        assert charm.tracing.otlp_grpc_endpoint() == f"{host}:4317"
+        assert charm.tracing.otlp_http_endpoint() == f"{host}:4318"
+        assert charm.tracing.otlp_http_endpoint() == f"{host}:4318"
 
         rel = charm.model.get_relation("tracing")
         assert charm.tracing.is_ready(rel)


### PR DESCRIPTION
- adds an `endpoint_removed` event for charm usage
- no longer raises exceptions when databag contents are invalid
- public `is_ready` check for charm usage