### PR TITLE
Build on and run on 22.04 only

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,13 +10,3 @@ bases:
       - name: "ubuntu"
         channel: "22.04"
 
-parts:
-  charm:
-    charm-binary-python-packages:
-      - "jsonschema==4.17.0"
-      - "pydantic < 2"
-      - "importlib-metadata~=6.0.0"
-      - "opentelemetry-exporter-otlp-proto-grpc==1.17.0"
-      - grpcio
-      - grpcio-tools
-

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,6 +8,15 @@ bases:
         channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
-      - name: "ubuntu"
         channel: "22.04"
+
+parts:
+  charm:
+    charm-binary-python-packages:
+      - "jsonschema==4.17.0"
+      - "pydantic < 2"
+      - "importlib-metadata~=6.0.0"
+      - "opentelemetry-exporter-otlp-proto-grpc==1.17.0"
+      - grpcio
+      - grpcio-tools
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,3 @@ lightkube-models==1.24.1.4
 # pydeps inherited from charm libs
 opentelemetry-exporter-otlp-proto-grpc
 pydantic < 2
-grpcio
-grpcio-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ lightkube-models==1.24.1.4
 # pydeps inherited from charm libs
 opentelemetry-exporter-otlp-proto-grpc
 pydantic < 2
+grpcio
+grpcio-tools


### PR DESCRIPTION
## Issue
Charm fails on install hook:
```
File "/var/lib/juju/agents/unit-tempo-k8s-0/charm/venv/grpc/_compression.py", line 20, in <module>
     from grpc._cython import cygrpc
 ImportError: cannot import name 'cygrpc' from 'grpc._cython' (/var/lib/juju/agents/unit-tempo-k8s-0/charm/venv/grpc/_cython/__init__.py)
```

The issue is that we are running on 20.04 (py38), but the cygrpc name is for a py310:

```
root@tempo-0:/var/lib/juju# find / -type f -name "cygrpc*"
/var/lib/juju/agents/unit-tempo-0/charm/venv/grpc/_cython/cygrpc.cpython-310-x86_64-linux-gnu.so

root@tempo-0:/var/lib/juju# cat /etc/os-release 
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
```

## Solution
Build on and run on 22.04 only.

Fixes #37.


## Context
It is possible that this is a result of moving packages to `charm-binary-python-packages`. Haven't checked yet though.
The charm isn't stable yet so it should be fairly safe to drop 20.04 (see https://bugs.launchpad.net/juju/+bug/2030110).

## Testing Instructions
Deploy the charm.


## Release Notes
Build on and run on 22.04 only.
