### PR TITLE
[doc] replace `charm_instrumentation` with `charm_tracing`

### DIFF
--- a/lib/charms/tempo_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v0/charm_tracing.py
@@ -86,7 +86,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-grpc==1.17.0"]
 

--- a/lib/charms/tempo_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v0/charm_tracing.py
@@ -313,7 +313,7 @@ def trace_charm(
     method calls on instances of this class.
 
     Usage:
-    >>> from charms.tempo_k8s.v0.charm_instrumentation import trace_charm
+    >>> from charms.tempo_k8s.v0.charm_tracing import trace_charm
     >>> from charms.tempo_k8s.v0.tracing import TracingEndpointProvider
     >>> from ops import CharmBase
     >>>
@@ -370,7 +370,7 @@ def _autoinstrument(
 
     Usage:
 
-    >>> from charms.tempo_k8s.v0.charm_instrumentation import _autoinstrument
+    >>> from charms.tempo_k8s.v0.charm_tracing import _autoinstrument
     >>> from ops.main import main
     >>> _autoinstrument(
     >>>         MyCharm,

--- a/tests/integration/tester/src/charm.py
+++ b/tests/integration/tester/src/charm.py
@@ -6,9 +6,6 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-import opentelemetry
-from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from charms.tempo_k8s.v0.charm_instrumentation import trace_charm
 from charms.tempo_k8s.v0.tempo_scrape import TracingEndpointProvider
 from ops.charm import CharmBase, PebbleReadyEvent
 from ops.main import main
@@ -20,6 +17,9 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import Layer
+
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
+from charms.tempo_k8s.v0.charm_tracing import trace_charm
 
 logger = logging.getLogger(__name__)
 TRACING_APP_NAME = "TempoTesterCharm"

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import pytest
-from charms.tempo_k8s.v0.charm_instrumentation import _charm_tracing_disabled
+from charms.tempo_k8s.v0.charm_tracing import charm_tracing_disabled
 from interface_tester import InterfaceTester
 from ops.pebble import Layer
 from scenario.state import Container, State
@@ -12,15 +12,15 @@ from charm import TempoCharm
 
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.
-# this fixture is used by the test runner of charm-relation-interfaces to test traefik's compliance
+# this fixture is used by the test runner of charm-relation-interfaces to test tempo's compliance
 # with the interface specifications.
 # DO NOT MOVE OR RENAME THIS FIXTURE! If you need to, you'll need to open a PR on
-# https://github.com/canonical/charm-relation-interfaces and change traefik's test configuration
+# https://github.com/canonical/charm-relation-interfaces and change tempo's test configuration
 # to include the new identifier/location.
 @pytest.fixture
 def interface_tester(interface_tester: InterfaceTester):
     with patch("charm.KubernetesServicePatch"):
-        with _charm_tracing_disabled():
+        with charm_tracing_disabled():
             interface_tester.configure(
                 charm_type=TempoCharm,
                 state_template=State(


### PR DESCRIPTION
Follow up on #43 with more renames (doc fix).