### PR TITLE
Sync tracing LIBPATCH

### DIFF
--- a/lib/charms/tempo_k8s/v0/tracing.py
+++ b/lib/charms/tempo_k8s/v0/tracing.py
@@ -93,7 +93,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 7
 
 PYDEPS = ["pydantic<2.0"]
 


### PR DESCRIPTION
## Issue
Tracing LIBPATCH is too high, 0.8.

The ERROR downgrade [didn't get published](https://github.com/canonical/tempo-k8s-operator/actions/runs/6160893608/job/16718862727#step:3:58) to charmhub because we overbumped LIBPATCH
```
Library charms.tempo_k8s.v0.tracing has a wrong LIBPATCH number, it's too high and needs to be consecutive, Charmhub highest version is 0.6.
```

## Solution
Sync with charmhub, 0.7.
