### PR TITLE
Check if tracing is ready before exposing its endpoint in tempo charm

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -263,7 +263,7 @@ class TempoCharm(CharmBase):
         # the charm container and the tempo workload container have apparently the same
         # IP, so we can talk to tempo at localhost.
         # TODO switch to HTTPS once SSL support is added
-        if self._tracing.is_ready():
+        if self.tempo.is_ready():
             return f"http://localhost:{self.tempo.receiver_ports['otlp_http']}"
         else:
             return None

--- a/src/charm.py
+++ b/src/charm.py
@@ -263,7 +263,10 @@ class TempoCharm(CharmBase):
         # the charm container and the tempo workload container have apparently the same
         # IP, so we can talk to tempo at localhost.
         # TODO switch to HTTPS once SSL support is added
-        return f"http://localhost:{self.tempo.receiver_ports['otlp_http']}"
+        if self._tracing.is_ready():
+            return f"http://localhost:{self.tempo.receiver_ports['otlp_http']}"
+        else:
+            return None
 
     def _on_collect_unit_status(self, e: CollectStatusEvent):
         if not self.tempo.container.can_connect():

--- a/src/charm.py
+++ b/src/charm.py
@@ -265,8 +265,8 @@ class TempoCharm(CharmBase):
         # TODO switch to HTTPS once SSL support is added
         if self.tempo.is_ready():
             return f"http://localhost:{self.tempo.receiver_ports['otlp_http']}"
-        else:
-            return None
+
+        return None
 
     def _on_collect_unit_status(self, e: CollectStatusEvent):
         if not self.tempo.container.can_connect():


### PR DESCRIPTION
## Issue
There's a transient error status on tempo startup as charm-tracing lib races with tempo startup.


## Solution
Add an `is_ready` guard before exposing tempo endpoint.

