### PR TITLE
Upgrade Tempo to 2.4.0 with adjusting config properties/defaults

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -2,7 +2,7 @@ To manually test and develop tempo:
 
     charmcraft pack 
     charmcraft pack -p ./tests/integration/tester/ 
-    j deploy ./tempo-k8s_ubuntu-22.04-amd64.charm tempo --resource tempo-image=grafana/tempo:1.5.0
+    j deploy ./tempo-k8s_ubuntu-22.04-amd64.charm tempo --resource tempo-image=grafana/tempo:2.4.0
 
 you need to always deploy at least 2 units of tester:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ juju deploy tempo-k8s # --trust (use when cluster has RBAC enabled)
 
 ## OCI Images
 
-This charm, by default, deploys `grafana/tempo:1.5.0`.
+This charm, by default, deploys `grafana/tempo:2.4.0`.
 
 ## Contributing
 

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -105,7 +105,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 PYDEPS = ["pydantic"]
 

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -577,7 +577,7 @@ class TracingEndpointProvider(Object):
         """All v2 relations active on this endpoint."""
         return [r for r in self._charm.model.relations[self._relation_name] if self.is_v2(r)]
 
-    def publish_receivers(self, receivers: Iterable[RawReceiver]):
+    def publish_receivers(self, receivers: Sequence[RawReceiver]):
         """Let all requirers know that these receivers are active and listening."""
         if not self._charm.unit.is_leader():
             raise RuntimeError("only leader can do this")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,7 +20,7 @@ resources:
     description: OCI image for Tempo
     # Included for simplicity in integration tests
     # see https://hub.docker.com/r/grafana/tempo/tags
-    upstream-source: grafana/tempo:1.5.0
+    upstream-source: grafana/tempo:2.4.0
 
 provides:
   profiling-endpoint:

--- a/src/charm.py
+++ b/src/charm.py
@@ -157,7 +157,7 @@ class TempoCharm(CharmBase):
         requested_receivers = self._requested_receivers()
         # publish requested protocols to all v2 relations
         self._tracing.publish_receivers(
-            ((p, self.tempo.receiver_ports[p]) for p in requested_receivers)
+            [(p, self.tempo.receiver_ports[p]) for p in requested_receivers]
         )
 
         # if the receivers have changed, we need to reconfigure tempo

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -94,7 +94,6 @@ class Tempo:
         return yaml.safe_dump(
             {
                 "auth_enabled": False,
-                "search_enabled": True,
                 "server": {
                     "http_listen_port": self.tempo_port,
                     "grpc_listen_port": self.receiver_ports["tempo_grpc"],
@@ -108,7 +107,7 @@ class Tempo:
                 "ingester": {
                     "trace_idle_period": "10s",
                     "max_block_bytes": 100,
-                    "max_block_duration": "5m",
+                    "max_block_duration": "30m",
                 },
                 "compactor": {
                     "compaction": {
@@ -118,7 +117,7 @@ class Tempo:
                         "max_compaction_objects": 1000000,
                         "block_retention": "1h",
                         "compacted_block_retention": "10m",
-                        "flush_size_bytes": 5242880,
+                        "v2_out_buffer_bytes": 5242880,
                     }
                 },
                 # see https://grafana.com/docs/tempo/latest/configuration/#storage
@@ -134,8 +133,8 @@ class Tempo:
                         },
                         "pool": {
                             # number of traces per index record
-                            "max_workers": 100,
-                            "queue_depth": 10000,
+                            "max_workers": 400,
+                            "queue_depth": 20000,
                         },
                     }
                 },


### PR DESCRIPTION
## Issue
Upgrade Tempo to the latest image (2.4.0).

## Testing Instructions
Run `charmcraft pack` on the charm and run the following commands:

```
juju deploy cos-lite --trust --channel edge
juju deploy ./tempo-k8s_ubuntu-22.04-amd64.charm tempo --resource tempo-image=grafana/tempo:2.4.0
(once everything settles down)
jhack imatrix fill
```

Bundle:
```
bundle: kubernetes
applications:
  alertmanager:
    charm: alertmanager-k8s
    channel: edge
    revision: 103
    series: focal
    resources:
      alertmanager-image: 87
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  catalogue:
    charm: catalogue-k8s
    channel: edge
    revision: 33
    series: focal
    resources:
      catalogue-image: 32
    scale: 1
    options:
      description: "Canonical Observability Stack Lite, or COS Lite, is a light-weight,
        highly-integrated, \nJuju-based observability suite running on Kubernetes.\n"
      tagline: Model-driven Observability Stack deployed with a single command.
      title: Canonical Observability Stack
    constraints: arch=amd64
    trust: true
  grafana:
    charm: grafana-k8s
    channel: edge
    revision: 106
    series: focal
    resources:
      grafana-image: 67
      litestream-image: 43
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: edge
    revision: 122
    series: focal
    resources:
      loki-image: 91
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  prometheus:
    charm: prometheus-k8s
    channel: edge
    revision: 171
    series: focal
    resources:
      prometheus-image: 140
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  tempo:
    charm: local:tempo-k8s-0
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
  traefik:
    charm: traefik-k8s
    channel: edge
    revision: 170
    series: focal
    resources:
      traefik-image: 158
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - traefik:ingress-per-unit
  - prometheus:ingress
- - traefik:ingress-per-unit
  - loki:ingress
- - traefik:traefik-route
  - grafana:ingress
- - traefik:ingress
  - alertmanager:ingress
- - prometheus:alertmanager
  - alertmanager:alerting
- - grafana:grafana-source
  - prometheus:grafana-source
- - grafana:grafana-source
  - loki:grafana-source
- - grafana:grafana-source
  - alertmanager:grafana-source
- - loki:alertmanager
  - alertmanager:alerting
- - prometheus:metrics-endpoint
  - traefik:metrics-endpoint
- - prometheus:metrics-endpoint
  - alertmanager:self-metrics-endpoint
- - prometheus:metrics-endpoint
  - loki:metrics-endpoint
- - prometheus:metrics-endpoint
  - grafana:metrics-endpoint
- - grafana:grafana-dashboard
  - loki:grafana-dashboard
- - grafana:grafana-dashboard
  - prometheus:grafana-dashboard
- - grafana:grafana-dashboard
  - alertmanager:grafana-dashboard
- - catalogue:ingress
  - traefik:ingress
- - catalogue:catalogue
  - grafana:catalogue
- - catalogue:catalogue
  - prometheus:catalogue
- - catalogue:catalogue
  - alertmanager:catalogue
- - catalogue:catalogue
  - loki:catalogue
- - loki:logging
  - tempo:logging
- - loki:logging
  - traefik:logging
- - tempo:tracing
  - alertmanager:tracing
- - tempo:grafana-dashboard
  - grafana:grafana-dashboard
- - tempo:grafana-source
  - grafana:grafana-source
- - tempo:tracing
  - grafana:tracing
- - tempo:tracing
  - loki:tracing
- - tempo:metrics-endpoint
  - prometheus:metrics-endpoint
- - tempo:tracing
  - prometheus:tracing
- - tempo:tracing
  - traefik:tracing
- - traefik:grafana-dashboard
  - grafana:grafana-dashboard
- - traefik:ingress
  - tempo:ingress
```

## Release Notes
Upgrade of Tempo workload to 2.4.0, adjusting configuration properties names and default values according to Tempo's changelogs.
