### PR TITLE
fixed tracing and charm-tracing libs

### DIFF
--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -104,7 +104,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic"]
 
@@ -817,8 +817,13 @@ class TracingEndpointRequirer(Object):
         endpoint = self._get_endpoint(relation or self._relation, protocol=protocol)
         if not endpoint:
             requested_protocols = set()
-            for relation in self.relations:
-                databag = TracingRequirerAppData.load(relation.data[self._charm.app])
+            relations = [relation] if relation else self.relations
+            for relation in relations:
+                try:
+                    databag = TracingRequirerAppData.load(relation.data[self._charm.app])
+                except DataValidationError:
+                    continue
+
                 requested_protocols.update(databag.receivers)
 
             if protocol not in requested_protocols:

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,6 +30,7 @@ from ops.charm import (
 )
 from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus, Relation, WaitingStatus
+
 from tempo import Tempo
 
 logger = logging.getLogger(__name__)

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -3,11 +3,12 @@
 from unittest.mock import patch
 
 import pytest
-from charm import TempoCharm
 from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
 from interface_tester import InterfaceTester
 from ops.pebble import Layer
 from scenario.state import Container, State
+
+from charm import TempoCharm
 
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
 import pytest
-from charm import TempoCharm
 from scenario import Context
+
+from charm import TempoCharm
 
 
 @pytest.fixture

--- a/tests/scenario/test_tracing_legacy.py
+++ b/tests/scenario/test_tracing_legacy.py
@@ -2,11 +2,16 @@ import json
 import socket
 
 import pytest
-from charm import TempoCharm
 from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
-from charms.tempo_k8s.v1.tracing import TracingProviderAppData as TracingProviderAppDataV1
-from charms.tempo_k8s.v2.tracing import TracingProviderAppData as TracingProviderAppDataV2
+from charms.tempo_k8s.v1.tracing import (
+    TracingProviderAppData as TracingProviderAppDataV1,
+)
+from charms.tempo_k8s.v2.tracing import (
+    TracingProviderAppData as TracingProviderAppDataV2,
+)
 from scenario import Container, Relation, State
+
+from charm import TempoCharm
 
 NO_RECEIVERS = 13
 """Number of supported receivers (incl. deprecated legacy ones)."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tempo import Tempo
 
 


### PR DESCRIPTION
## Issue
Fixes #85 
Also slightly adjusts the behaviour of `tracing` on the `get_endpoint` path:
- when deciding whether to raise an exception (when checking for requests if there is no response yet), tolerate empty databags 
- only search for responses in the specific relation you're `get_endpoint`ing from, instead of all of them, if you provided one

## Solution
bumps for tracing and charm_tracing

added a bunch of tests covering all leadership/remote data provided combinations


## Testing Instructions
itests should take care of most of it, but we should test it with cos-lite to be sure.

