### PR TITLE
Add documentation to the tempo charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,9 +10,21 @@ assumes:
   - juju >= 3.4.0
 
 description: |
-  Tempo is a distributed tracing backend by Grafana.
+  Tempo provides tracing endpoints for charms and a decorator to auto-instrument the 
+  charms to push traces using common opensource tracing protocols, including Jaeger,
+  Zipkin, and OpenTelemetry. Then, propagate those pushed traces into a Grafana instance.
+
 summary: |
   Tempo is a distributed tracing backend by Grafana.
+
+links:
+  documentation: https://discourse.charmhub.io/t/tempo-k8s-docs-index/14005
+  website:
+    - https://charmhub.io/tempo-k8s
+  source:
+    - https://github.com/canonical/tempo-k8s-operator
+  issues:
+    - https://github.com/canonical/tempo-k8s-operator/issues
 
 containers:
   tempo:


### PR DESCRIPTION
## Issue
- There is no charmhub.io docset for tempo-k8s.
- The description is too short.

## Solution
- Created a docset for tempo-k8s https://discourse.charmhub.io/t/tempo-k8s-docs-index/14005
and linked charm to that docset.


