### PR TITLE
Set total block retention to 30 days

### DIFF
--- a/src/tempo.py
+++ b/src/tempo.py
@@ -191,8 +191,9 @@ class Tempo:
                     "compaction_window": "1h",
                     # maximum size of compacted blocks
                     "max_compaction_objects": 1000000,
-                    "block_retention": "1h",
-                    "compacted_block_retention": "10m",
+                    # total trace retention
+                    "block_retention": "30d",
+                    "compacted_block_retention": "1h",
                     "v2_out_buffer_bytes": 5242880,
                 }
             },

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -192,7 +192,7 @@ class Tempo:
                     # maximum size of compacted blocks
                     "max_compaction_objects": 1000000,
                     # total trace retention
-                    "block_retention": "30d",
+                    "block_retention": "720h",
                     "compacted_block_retention": "1h",
                     "v2_out_buffer_bytes": 5242880,
                 }


### PR DESCRIPTION
## Issue
Traces seem to disappear after a longer period.

## Solution
Set default `block_retention` to 30 days. Set also `compacted_block_retention` that says how long blocks should stay around after they've been compacted


## Context
See https://github.com/grafana/tempo/blob/main/modules/compactor/config.go#L38 and https://grafana.com/docs/tempo/latest/configuration/#compactor for context.


## Testing Instructions
- deploy tempo with something that posts traces
- keep it running for more than 1h
- you should still see the original traces

## Release Notes
<!-- A digestable summary of the change in this PR -->
