### PR TITLE
use pytest version < 8.2.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
 [testenv:unit]
 description = Run unit tests
 deps =
-    pytest
+    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
     coverage[toml]
     .[lib_pydeps]
     -r{toxinidir}/requirements.txt
@@ -60,7 +60,7 @@ commands =
 [testenv:scenario]
 description = Run scenario tests
 deps =
-    pytest
+    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
     coverage[toml]
     ops-scenario>=4.0.3
     .[lib_pydeps]
@@ -73,7 +73,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest
+    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
     # see https://github.com/juju/python-libjuju/issues/1025
     juju<=3.3.0,>=3.0
     pytest-operator
@@ -85,7 +85,7 @@ commands =
 [testenv:interface]
 description = Run interface tests
 deps =
-    pytest
+    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
     -r{toxinidir}/requirements.txt
     .[lib_pydeps]
     pytest-interface-tester


### PR DESCRIPTION
## Issue
When using with the most recent version of pytest 8.2.0, asyncio-0.21.1 is used which breaks the fixtures with error: AttributeError: 'FixtureDef' object has no attribute 'unittest'.
https://github.com/charmed-kubernetes/pytest-operator/issues/131


## Solution
Use pytest version < 8.2.0 for our tests until upstream is fixed.


