### PR TITLE
Fix race between pebble-ready and relation-created

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -177,7 +177,9 @@ class TempoCharm(CharmBase):
             self.tempo.update_config(self._requested_receivers())
             # sync scheme change with traefik and related consumers
             self._configure_ingress(_)
-            self.tempo.restart()
+
+            if self.tempo.is_tempo_service_defined:
+                self.tempo.restart()
 
         # sync the server cert with the charm container.
         # technically, because of charm tracing, this will be called first thing on each event
@@ -247,7 +249,7 @@ class TempoCharm(CharmBase):
         if not updated:
             logger.debug("Config not updated; skipping tempo restart")
         if updated:
-            restarted = self.tempo.restart()
+            restarted = self.tempo.is_tempo_service_defined and self.tempo.restart()
             if not restarted:
                 # assume that this will be handled at the next pebble-ready
                 logger.debug("Cannot reconfigure/restart tempo at this time.")

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -3,12 +3,11 @@ from unittest.mock import MagicMock
 
 import pytest
 import yaml
+from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
+from charms.tempo_k8s.v2.tracing import TracingRequirerAppData
 from ops import pebble
 from scenario import Container, Mount, Relation, State
 from scenario.sequences import check_builtin_sequences
-
-from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
-from charms.tempo_k8s.v2.tracing import TracingRequirerAppData
 from tempo import Tempo
 
 TEMPO_CHARM_ROOT = Path(__file__).parent.parent.parent
@@ -91,8 +90,8 @@ def test_tempo_restart_on_ingress_v2_changed(context, tmp_path, requested_protoc
     assert new_config == expected_config
     # AND restarts the pebble service.
     assert (
-            context.output_state.get_container("tempo").service_status["tempo"]
-            is pebble.ServiceStatus.ACTIVE
+        context.output_state.get_container("tempo").service_status["tempo"]
+        is pebble.ServiceStatus.ACTIVE
     )
 
 
@@ -110,7 +109,7 @@ def test_tempo_tracing_created_before_pebble_ready(context, tmp_path):
         remote_app_data={"receivers": '["otlp_http"]'},
         local_app_data={
             "receivers": '[{"protocol": {"name": "otlp_grpc", "type": "grpc"} , "url": "foo.com:10"}, '
-                         '{"protocol": {"name": "otlp_http", "type": "http"}, "url": "http://foo.com:11"}, '
+            '{"protocol": {"name": "otlp_http", "type": "http"}, "url": "http://foo.com:11"}, '
         },
     )
     state = State(leader=True, containers=[tempo], relations=[tracing])


### PR DESCRIPTION
## Issue
When tempo receives tracing-relation-created before pebble-ready it tries to start a service that hasn't been defined yet.

## Solution
guard the Tempo.restart() paths with checks that verify that the service is defined

