### PR TITLE
tracing util for charm_tracing

### DIFF
--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -72,6 +72,7 @@ follows
 import enum
 import json
 import logging
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -82,6 +83,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Union,
     cast,
 )
 
@@ -921,3 +923,66 @@ class TracingEndpointRequirer(Object):
 
             return None
         return endpoint
+
+
+def charm_tracing_config(
+    endpoint_requirer: TracingEndpointRequirer, cert_path: Optional[Union[Path, str]]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Utility function to determine the charm_tracing config you will likely want.
+
+    If no endpoint is provided:
+     disable charm tracing.
+    If https endpoint is provided but cert_path is not found on disk:
+     disable charm tracing.
+    If https endpoint is provided and cert_path is None:
+     ERROR
+    Else:
+     proceed with charm tracing (with or without tls, as appropriate)
+
+    Usage:
+      If you are using charm_tracing >= v1.9:
+    >>> from lib.charms.tempo_k8s.v1.charm_tracing import trace_charm
+    >>> from lib.charms.tempo_k8s.v2.tracing import charm_tracing_config
+    >>> @trace_charm(tracing_endpoint="my_endpoint", cert_path="cert_path")
+    >>> class MyCharm(...):
+    >>>     _cert_path = "/path/to/cert/on/charm/container.crt"
+    >>>     def __init__(self, ...):
+    >>>         self.tracing = TracingEndpointRequirer(...)
+    >>>         self.my_endpoint, self.cert_path = charm_tracing_config(
+    ...             self.tracing, self._cert_path)
+
+      If you are using charm_tracing < v1.9:
+    >>> from lib.charms.tempo_k8s.v1.charm_tracing import trace_charm
+    >>> from lib.charms.tempo_k8s.v2.tracing import charm_tracing_config
+    >>> @trace_charm(tracing_endpoint="my_endpoint", cert_path="cert_path")
+    >>> class MyCharm(...):
+    >>>     _cert_path = "/path/to/cert/on/charm/container.crt"
+    >>>     def __init__(self, ...):
+    >>>         self.tracing = TracingEndpointRequirer(...)
+    >>>         self._my_endpoint, self._cert_path = charm_tracing_config(
+    ...             self.tracing, self._cert_path)
+    >>>     @property
+    >>>     def my_endpoint(self):
+    >>>         return self._my_endpoint
+    >>>     @property
+    >>>     def cert_path(self):
+    >>>         return self._cert_path
+
+    """
+    if not endpoint_requirer.is_ready():
+        return None, None
+
+    endpoint = endpoint_requirer.get_endpoint("otlp_http")
+    is_https = endpoint.startswith("https://")
+
+    if not is_https and cert_path is None:
+        return endpoint, None
+
+    if is_https and cert_path is None:
+        raise TracingError("Cannot send traces to an https endpoint without a certificate.")
+
+    if is_https and not Path(cert_path).exists():
+        # if endpoint is https BUT we don't have a server_cert yet: disable charm tracing until we do
+        return None, None
+
+    return endpoint, str(cert_path)


### PR DESCRIPTION
This PR adds a utility function to the tracing lib.

Other libraries that offer a tracing endpoint that could be used by charm_tracing could implement a function with the same signature so that charms can use this logic with minimal boilerplate.

Fixes #121 