### PR TITLE
instance attribute support for charm_tracing forward-declared definitions

### DIFF
--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -148,7 +148,7 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 

--- a/tests/scenario/test_charm_tracing.py
+++ b/tests/scenario/test_charm_tracing.py
@@ -47,7 +47,7 @@ class MyCharmSimple(CharmBase):
         return "foo.bar:80"
 
 
-autoinstrument(MyCharmSimple, MyCharmSimple.tempo)
+autoinstrument(MyCharmSimple, "tempo")
 
 
 def test_base_tracer_endpoint(caplog):
@@ -88,7 +88,7 @@ class MyCharmSubObject(CharmBase):
         return "foo.bar:80"
 
 
-autoinstrument(MyCharmSubObject, MyCharmSubObject.tempo, extra_types=[SubObject])
+autoinstrument(MyCharmSubObject, "tempo", extra_types=[SubObject])
 
 
 def test_subobj_tracer_endpoint(caplog):
@@ -116,7 +116,7 @@ class MyCharmInitAttr(CharmBase):
         return self._tempo
 
 
-autoinstrument(MyCharmInitAttr, MyCharmInitAttr.tempo)
+autoinstrument(MyCharmInitAttr, "tempo")
 
 
 def test_init_attr(caplog):
@@ -143,7 +143,7 @@ class MyCharmSimpleDisabled(CharmBase):
         return None
 
 
-autoinstrument(MyCharmSimpleDisabled, MyCharmSimpleDisabled.tempo)
+autoinstrument(MyCharmSimpleDisabled, "tempo")
 
 
 def test_base_tracer_endpoint_disabled(caplog):
@@ -190,7 +190,7 @@ class MyCharmSimpleEvent(CharmBase):
         return "foo.bar:80"
 
 
-autoinstrument(MyCharmSimpleEvent, MyCharmSimpleEvent.tempo)
+autoinstrument(MyCharmSimpleEvent, "tempo")
 
 
 def test_base_tracer_endpoint_event(caplog):
@@ -265,7 +265,7 @@ class MyCharmWithMethods(CharmBase):
         return "foo.bar:80"
 
 
-autoinstrument(MyCharmWithMethods, MyCharmWithMethods.tempo)
+autoinstrument(MyCharmWithMethods, "tempo")
 
 
 def test_base_tracer_endpoint_methods(caplog):
@@ -319,7 +319,7 @@ class MyCharmWithCustomEvents(CharmBase):
         return "foo.bar:80"
 
 
-autoinstrument(MyCharmWithCustomEvents, MyCharmWithCustomEvents.tempo)
+autoinstrument(MyCharmWithCustomEvents, "tempo")
 
 
 def test_base_tracer_endpoint_custom_event(caplog):
@@ -363,7 +363,7 @@ class MyRemoteCharm(CharmBase):
         return self.tracing.get_endpoint("otlp_http")
 
 
-autoinstrument(MyRemoteCharm, MyRemoteCharm.tempo)
+autoinstrument(MyRemoteCharm, "tempo")
 
 
 @pytest.mark.parametrize("leader", (True, False))
@@ -448,7 +448,7 @@ class MyRemoteBorkyCharm(CharmBase):
         return self._borky_return_value
 
 
-autoinstrument(MyRemoteBorkyCharm, MyRemoteBorkyCharm.tempo)
+autoinstrument(MyRemoteBorkyCharm, "tempo")
 
 
 @pytest.mark.parametrize("borky_return_value", (True, 42, object(), 0.2, [], (), {}))
@@ -462,7 +462,7 @@ def test_borky_tempo_return_value(borky_return_value, caplog):
 
     ctx.run("start", State())
     # traceback from the TypeError raised by _get_tracing_endpoint
-    assert "should return a tempo endpoint" in caplog.text
+    assert "should resolve to a tempo endpoint" in caplog.text
     # logger.exception in _setup_root_span_initializer
     assert "exception retrieving the tracing endpoint from" in caplog.text
     assert "proceeding with charm_tracing DISABLED." in caplog.text
@@ -515,7 +515,7 @@ class OtherObj:
         return 1 + 1
 
 
-autoinstrument(MyCharmStaticMethods, MyCharmStaticMethods.tempo, extra_types=[OtherObj])
+autoinstrument(MyCharmStaticMethods, "tempo", extra_types=[OtherObj])
 
 
 def test_trace_staticmethods(caplog):

--- a/tests/scenario/test_charm_tracing.py
+++ b/tests/scenario/test_charm_tracing.py
@@ -452,12 +452,12 @@ autoinstrument(MyRemoteBorkyCharm, "tempo")
 
 @pytest.mark.parametrize("borky_return_value", (True, 42, object(), 0.2, [], (), {}))
 def test_borky_tempo_return_value(borky_return_value, caplog):
-    """Verify that the charm exits 0 (with charm_tracing disabled) if the tempo() call returns bad values."""
+    """Verify that the charm exits 1 (even with charm_tracing disabled) if the tempo() call returns bad values."""
     # IF the charm's tempo endpoint getter returns anything but None or str
     MyRemoteBorkyCharm._borky_return_value = borky_return_value
     ctx = Context(MyRemoteBorkyCharm, meta=MyRemoteBorkyCharm.META)
     # WHEN you get any event
-    # THEN you're not totally good: self.tempo() will raise, but charm exec will still exit 0
+    # THEN the self.tempo getter will raise and charm exec will exit 1
 
     # traceback from the TypeError raised by _get_tracing_endpoint
     with pytest.raises(


### PR DESCRIPTION
This PR adds support for charm_tracing to grab the endpoint and cert it needs from instance attributes instead of properties and methods.

This is a nicety which in combination with #135 means any charm can enable/disable charm tracing and correctly configure it with/without TLS with a single line of code (plus the decorator).


before:

```
from lib....charm_tracing import charm_tracing

@charm_tracing(tracing_endpoint="foo", server_cert="bar")
class MyCharm(...):
    [...]
    def foo(self):
        # complicated logic to return None if we don't have tracing or we have tracing and tls but no cert yet
        return ... 
    def bar(self):
        return ...
```

after:
```
from lib....charm_tracing import charm_tracing
from lib....tracing import charm_tracing_config

@charm_tracing(tracing_endpoint="foo", server_cert="bar")
class MyCharm(...):
    def __init__(...):
        self.tracing = TracingEndpointRequirer(...)
        self.foo, self.bar = charm_tracing_config(self.tracing, "path/to/cert/")
```


Additionally:
- tuned down logs
- be less forgiving and raise if tracing_endpoint returns rubbish or raises, like we're doing in charm_logging