### PR TITLE
add service name -charm prefix

### DIFF
--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -294,8 +294,8 @@ def _setup_root_span_initializer(
         # self.handle = Handle(None, self.handle_kind, None)
 
         original_event_context = framework._event_context
-
-        _service_name = service_name or self.app.name
+        # default service name isn't just app name because it could conflict with the workload service name
+        _service_name = service_name or f"{self.app.name}-charm"
 
         resource = Resource.create(
             attributes={

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -146,7 +146,7 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -110,7 +110,10 @@ async def test_verify_traces_http(ops_test: OpsTest):
 
     found = False
     for trace in traces:
-        if trace["rootServiceName"] == APP_NAME + "-charm" and trace["rootTraceName"] == "charm exec":
+        if (
+            trace["rootServiceName"] == APP_NAME + "-charm"
+            and trace["rootTraceName"] == "charm exec"
+        ):
             found = True
 
     assert found, f"There's no trace of charm exec traces in tempo. {json.dumps(traces, indent=2)}"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -110,7 +110,7 @@ async def test_verify_traces_http(ops_test: OpsTest):
 
     found = False
     for trace in traces:
-        if trace["rootServiceName"] == APP_NAME and trace["rootTraceName"] == "charm exec":
+        if trace["rootServiceName"] == APP_NAME + "-charm" and trace["rootTraceName"] == "charm exec":
             found = True
 
     assert found, f"There's no trace of charm exec traces in tempo. {json.dumps(traces, indent=2)}"

--- a/tests/scenario/test_charm_tracing.py
+++ b/tests/scenario/test_charm_tracing.py
@@ -62,8 +62,8 @@ def test_base_tracer_endpoint(caplog):
         assert "Setting up span exporter to endpoint: foo.bar:80" in caplog.text
         assert "Starting root trace with id=" in caplog.text
         span = f.call_args_list[0].args[0][0]
-        assert span.resource.attributes["service.name"] == "frank"
-        assert span.resource.attributes["compose_service"] == "frank"
+        assert span.resource.attributes["service.name"] == "frank-charm"
+        assert span.resource.attributes["compose_service"] == "frank-charm"
         assert span.resource.attributes["charm_type"] == "MyCharmSimple"
 
 
@@ -130,8 +130,8 @@ def test_init_attr(caplog):
         ctx.run("start", State())
         assert "Setting up span exporter to endpoint: foo.bar:80" in caplog.text
         span = f.call_args_list[0].args[0][0]
-        assert span.resource.attributes["service.name"] == "frank"
-        assert span.resource.attributes["compose_service"] == "frank"
+        assert span.resource.attributes["service.name"] == "frank-charm"
+        assert span.resource.attributes["compose_service"] == "frank-charm"
         assert span.resource.attributes["charm_type"] == "MyCharmInitAttr"
 
 
@@ -216,7 +216,7 @@ def test_base_tracer_endpoint_event(caplog):
         assert span3.name == "charm exec"
 
         for span in spans:
-            assert span.resource.attributes["service.name"] == "frank"
+            assert span.resource.attributes["service.name"] == "frank-charm"
 
 
 def test_juju_topology_injection(caplog):
@@ -544,7 +544,7 @@ def test_trace_staticmethods(caplog):
         ]
 
         for span in spans:
-            assert span.resource.attributes["service.name"] == "jolene"
+            assert span.resource.attributes["service.name"] == "jolene-charm"
 
 
 def test_trace_staticmethods_bork(caplog):


### PR DESCRIPTION
Fixes #88 

# Issue:

If you deploy `grafana-k8s` as `grafana`, the service name for charm traces was 'grafana'. The traces generated by the grafana workload also had the same service name, resulting in confusion.

# Solution:

Service name for the charm tracer will now default to `<app name>-charm` so a conflict with the workload service name is less likely. 

