### PR TITLE
changed root span name to be more descriptive

### DIFF
--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -146,7 +146,7 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 
@@ -297,13 +297,14 @@ def _setup_root_span_initializer(
 
         _service_name = service_name or self.app.name
 
+        unit_name = self.unit.name
         resource = Resource.create(
             attributes={
                 "service.name": _service_name,
                 "compose_service": _service_name,
                 "charm_type": type(self).__name__,
                 # juju topology
-                "juju_unit": self.unit.name,
+                "juju_unit": unit_name,
                 "juju_application": self.app.name,
                 "juju_model": self.model.name,
                 "juju_model_uuid": self.model.uuid,
@@ -341,16 +342,18 @@ def _setup_root_span_initializer(
         _tracer = get_tracer(_service_name)  # type: ignore
         _tracer_token = tracer.set(_tracer)
 
-        dispatch_path = os.getenv("JUJU_DISPATCH_PATH", "")
+        dispatch_path = os.getenv("JUJU_DISPATCH_PATH", "")  # something like hooks/install
+        event_name = dispatch_path.split("/")[1] if "/" in dispatch_path else dispatch_path
+        root_span_name = f"{unit_name}: {event_name} event"
+        span = _tracer.start_span(root_span_name, attributes={"juju.dispatch_path": dispatch_path})
 
         # all these shenanigans are to work around the fact that the opentelemetry tracing API is built
         # on the assumption that spans will be used as contextmanagers.
         # Since we don't (as we need to close the span on framework.commit),
         # we need to manually set the root span as current.
-        span = _tracer.start_span("charm exec", attributes={"juju.dispatch_path": dispatch_path})
         ctx = set_span_in_context(span)
 
-        # log a trace id so we can look it up in tempo.
+        # log a trace id, so we can pick it up from the logs (and jhack) to look it up in tempo.
         root_trace_id = hex(span.get_span_context().trace_id)[2:]  # strip 0x prefix
         logger.debug(f"Starting root trace with id={root_trace_id!r}.")
 

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -146,7 +146,7 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -110,7 +110,9 @@ async def test_verify_traces_http(ops_test: OpsTest):
 
     found = False
     for trace in traces:
-        if trace["rootServiceName"] == APP_NAME and trace["rootTraceName"] == "charm exec":
+        if trace["rootServiceName"] == APP_NAME and trace["rootTraceName"].startswith(
+            f"{APP_NAME}/0"
+        ):
             found = True
 
     assert found, f"There's no trace of charm exec traces in tempo. {json.dumps(traces, indent=2)}"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -110,9 +110,8 @@ async def test_verify_traces_http(ops_test: OpsTest):
 
     found = False
     for trace in traces:
-        if (
-            trace["rootServiceName"] == APP_NAME + "-charm"
-            and trace["rootTraceName"].startswith(f"{APP_NAME}/0")
+        if trace["rootServiceName"] == APP_NAME + "-charm" and trace["rootTraceName"].startswith(
+            f"{APP_NAME}/0"
         ):
             found = True
 

--- a/tests/scenario/test_charm_tracing.py
+++ b/tests/scenario/test_charm_tracing.py
@@ -213,7 +213,7 @@ def test_base_tracer_endpoint_event(caplog):
         evt = span2.events[0]
         assert evt.name == "start"
 
-        assert span3.name == "charm exec"
+        assert span3.name == "frank/0: start event"
 
         for span in spans:
             assert span.resource.attributes["service.name"] == "frank"
@@ -286,7 +286,7 @@ def test_base_tracer_endpoint_methods(caplog):
             "method call: MyCharmWithMethods.c",
             "method call: MyCharmWithMethods._on_start",
             "event: start",
-            "charm exec",
+            "frank/0: start event",
         ]
 
 
@@ -339,7 +339,7 @@ def test_base_tracer_endpoint_custom_event(caplog):
             "event: foo",
             "method call: MyCharmWithCustomEvents._on_start",
             "event: start",
-            "charm exec",
+            "frank/0: start event",
         ]
         # only the charm exec span is a root
         assert not spans[-1].parent
@@ -540,7 +540,7 @@ def test_trace_staticmethods(caplog):
             "method call: OtherObj._staticmeth2",
             "method call: MyCharmStaticMethods._on_start",
             "event: start",
-            "charm exec",
+            "jolene/0: start event",
         ]
 
         for span in spans:


### PR DESCRIPTION
Fixes #111 

## Issue
right now all charm traces that show up in grafana have the same title: `charm exec`. 
Not very descriptive.

## Solution
Now it looks like `<unit-name>: <event> event`, for example `loki/1: foo-relation-changed event`
