### PR TITLE
[DO NOT MERGE] tracing middleware example

### DIFF
--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -594,3 +594,19 @@ def trace(obj: Union[Type, Callable]):
             raise UntraceableObjectError(
                 f"cannot create span from {type(obj)}; instrument {obj} manually."
             )
+
+
+from ops.middlewares import Middleware
+class TracingMiddleware(Middleware):
+    """Middleware to add tracing to your charm."""
+    def __init__(self, endpoint, cert):
+        self.endpoint = endpoint
+        self.cert = cert
+
+    # we could also achieve this in a slightly nicer way by using post_init instead,
+    # but that'd require us to refactor _setup_root_span_initializer to not directly do __init__
+    # patching.
+    def setup_class(self, charm_type: Type[CharmBase]):
+        _autoinstrument(charm_type, self.endpoint, self.cert)
+
+


### PR DESCRIPTION
example of how middleware definitions could be exposed to end-users

tandems:
- ops code: https://github.com/canonical/operator/pull/1274
- testing: https://github.com/canonical/ops-scenario/pull/146