### PR TITLE
removed excess receiver protocols from enum

### DIFF
--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -121,7 +121,6 @@ ReceiverProtocol = Literal[
     "zipkin",
     "otlp_grpc",
     "otlp_http",
-    "opencensus",
     "jaeger_grpc",
     "jaeger_thrift_http",
 ]
@@ -145,7 +144,6 @@ receiver_protocol_to_transport_protocol: Dict[ReceiverProtocol, TransportProtoco
     "zipkin": TransportProtocolType.http,
     "otlp_grpc": TransportProtocolType.grpc,
     "otlp_http": TransportProtocolType.http,
-    "opencensus": TransportProtocolType.grpc,
     "jaeger_thrift_http": TransportProtocolType.http,
     "jaeger_grpc": TransportProtocolType.grpc,
 }

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -124,8 +124,6 @@ ReceiverProtocol = Literal[
     "opencensus",
     "jaeger_grpc",
     "jaeger_thrift_http",
-    "jaeger_thrift_compact",
-    "jaeger_thrift_binary",
 ]
 
 RawReceiver = Tuple[ReceiverProtocol, str]
@@ -141,7 +139,6 @@ class TransportProtocolType(str, enum.Enum):
 
     http = "http"
     grpc = "grpc"
-    udp = "udp"
 
 
 receiver_protocol_to_transport_protocol: Dict[ReceiverProtocol, TransportProtocolType] = {
@@ -151,8 +148,6 @@ receiver_protocol_to_transport_protocol: Dict[ReceiverProtocol, TransportProtoco
     "opencensus": TransportProtocolType.grpc,
     "jaeger_thrift_http": TransportProtocolType.http,
     "jaeger_grpc": TransportProtocolType.grpc,
-    "jaeger_thrift_compact": TransportProtocolType.udp,
-    "jaeger_thrift_binary": TransportProtocolType.udp,
 }
 """A mapping between telemetry protocols and their corresponding transport protocol.
 """

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -137,12 +137,8 @@ class TransportProtocolType(str, enum.Enum):
     grpc = "grpc"
 
 
-receiver_protocol_to_transport_protocol = {
+receiver_protocol_to_transport_protocol: Dict[ReceiverProtocol, TransportProtocolType] = {
     "zipkin": TransportProtocolType.http,
-    "kafka": TransportProtocolType.http,
-    "opencensus": TransportProtocolType.http,
-    "tempo_http": TransportProtocolType.http,
-    "tempo_grpc": TransportProtocolType.grpc,
     "otlp_grpc": TransportProtocolType.grpc,
     "otlp_http": TransportProtocolType.http,
 }

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -116,10 +116,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_RELATION_NAME = "tracing"
 RELATION_INTERFACE_NAME = "tracing"
 
+# Supported list rationale https://github.com/canonical/tempo-coordinator-k8s-operator/issues/8
 ReceiverProtocol = Literal[
     "zipkin",
     "otlp_grpc",
     "otlp_http",
+    "opencensus",
+    "jaeger_grpc",
+    "jaeger_thrift_http",
+    "jaeger_thrift_compact",
+    "jaeger_thrift_binary",
 ]
 
 RawReceiver = Tuple[ReceiverProtocol, str]
@@ -135,12 +141,18 @@ class TransportProtocolType(str, enum.Enum):
 
     http = "http"
     grpc = "grpc"
+    udp = "udp"
 
 
 receiver_protocol_to_transport_protocol: Dict[ReceiverProtocol, TransportProtocolType] = {
     "zipkin": TransportProtocolType.http,
     "otlp_grpc": TransportProtocolType.grpc,
     "otlp_http": TransportProtocolType.http,
+    "opencensus": TransportProtocolType.grpc,
+    "jaeger_thrift_http": TransportProtocolType.http,
+    "jaeger_grpc": TransportProtocolType.grpc,
+    "jaeger_thrift_compact": TransportProtocolType.udp,
+    "jaeger_thrift_binary": TransportProtocolType.udp,
 }
 """A mapping between telemetry protocols and their corresponding transport protocol.
 """

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -107,7 +107,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 PYDEPS = ["pydantic"]
 
@@ -118,10 +118,6 @@ RELATION_INTERFACE_NAME = "tracing"
 
 ReceiverProtocol = Literal[
     "zipkin",
-    "kafka",
-    "opencensus",
-    "tempo_http",
-    "tempo_grpc",
     "otlp_grpc",
     "otlp_http",
 ]


### PR DESCRIPTION
## Issue
This helps address issue #https://github.com/canonical/tempo-coordinator-k8s-operator/issues/8
