### PR TITLE
remove stale opentelemetry_sdk packages

### DIFF
--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -366,16 +366,19 @@ def _remove_stale_otel_sdk_packages():
 
     See https://github.com/canonical/grafana-agent-operator/issues/146 and
     https://bugs.launchpad.net/juju/+bug/2058335 for more context.
+
+    This only does something if executed on an upgrade-charm event.
     """
-    # Find any opentelemetry_sdk distributions
-    otel_sdk_distributions = list(distributions(name="opentelemetry_sdk"))
-    # If there are more than 2, inspect them and infer that any with 0 entrypoints are stale
-    if len(otel_sdk_distributions) > 1:
-        for d in otel_sdk_distributions:
-            if len(d.entry_points) == 0:
-                # Distribution appears to be empty.  Remove it
-                logger.debug(f"Removing empty opentelemetry_sdk distribution at: {d._path}")
-                shutil.rmtree(d._path)
+    if os.getenv("JUJU_HOOK_PATH") == "hooks/upgrade-charm":
+        # Find any opentelemetry_sdk distributions
+        otel_sdk_distributions = list(distributions(name="opentelemetry_sdk"))
+        # If there are more than 2, inspect them and infer that any with 0 entrypoints are stale
+        if len(otel_sdk_distributions) > 1:
+            for d in otel_sdk_distributions:
+                if len(d.entry_points) == 0:
+                    # Distribution appears to be empty.  Remove it
+                    logger.debug(f"Removing empty opentelemetry_sdk distribution at: {d._path}")
+                    shutil.rmtree(d._path)
 
 
 def _setup_root_span_initializer(

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -362,25 +362,27 @@ def _get_server_cert(
 
 
 def _remove_stale_otel_sdk_packages():
-    """Hack to remove stale opentelemetry sdk packages from the environment.
+    """Hack to remove stale opentelemetry sdk packages from the charm's python venv.
 
     See https://github.com/canonical/grafana-agent-operator/issues/146 and
-    https://bugs.launchpad.net/juju/+bug/2058335 for more context.  This patch can be removed after
+    https://bugs.launchpad.net/juju/+bug/2058335 for more context. This patch can be removed after
     this juju issue is resolved and sufficient time has passed to expect most users of this library
     have migrated to the patched version of juju.
 
     This only does something if executed on an upgrade-charm event.
     """
     if os.getenv("JUJU_DISPATCH_PATH") == "hooks/upgrade-charm":
+        logger.debug("Executing _remove_stale_otel_sdk_packages patch on charm upgrade")
         # Find any opentelemetry_sdk distributions
         otel_sdk_distributions = list(distributions(name="opentelemetry_sdk"))
-        # If there are more than 2, inspect them and infer that any with 0 entrypoints are stale
+        # If there is more than 1, inspect each and if it has 0 entrypoints, infer that it is stale
         if len(otel_sdk_distributions) > 1:
-            for d in otel_sdk_distributions:
-                if len(d.entry_points) == 0:
-                    # Distribution appears to be empty.  Remove it
-                    logger.debug(f"Removing empty opentelemetry_sdk distribution at: {d._path}")  # type: ignore
-                    shutil.rmtree(d._path)  # type: ignore
+            for distribution in otel_sdk_distributions:
+                if len(distribution.entry_points) == 0:
+                    # Distribution appears to be empty. Remove it
+                    path = distribution._path  # type: ignore
+                    logger.debug(f"Removing empty opentelemetry_sdk distribution at: {path}")
+                    shutil.rmtree(path)
 
 
 def _setup_root_span_initializer(
@@ -415,6 +417,9 @@ def _setup_root_span_initializer(
         _service_name = service_name or f"{self.app.name}-charm"
 
         unit_name = self.unit.name
+        # apply hacky patch to remove stale opentelemetry sdk packages on upgrade-charm.
+        # it could be trouble if someone ever decides to implement their own tracer parallel to
+        # ours and before the charm has inited. We assume they won't.
         _remove_stale_otel_sdk_packages()
         resource = Resource.create(
             attributes={

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -369,7 +369,7 @@ def _remove_stale_otel_sdk_packages():
 
     This only does something if executed on an upgrade-charm event.
     """
-    if os.getenv("JUJU_HOOK_PATH") == "hooks/upgrade-charm":
+    if os.getenv("JUJU_DISPATCH_PATH") == "hooks/upgrade-charm":
         # Find any opentelemetry_sdk distributions
         otel_sdk_distributions = list(distributions(name="opentelemetry_sdk"))
         # If there are more than 2, inspect them and infer that any with 0 entrypoints are stale

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -365,7 +365,9 @@ def _remove_stale_otel_sdk_packages():
     """Hack to remove stale opentelemetry sdk packages from the environment.
 
     See https://github.com/canonical/grafana-agent-operator/issues/146 and
-    https://bugs.launchpad.net/juju/+bug/2058335 for more context.
+    https://bugs.launchpad.net/juju/+bug/2058335 for more context.  This patch can be removed after
+    this juju issue is resolved and sufficient time has passed to expect most users of this library
+    have migrated to the patched version of juju.
 
     This only does something if executed on an upgrade-charm event.
     """

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -176,11 +176,11 @@ import functools
 import inspect
 import logging
 import os
+import shutil
 from contextlib import contextmanager
 from contextvars import Context, ContextVar, copy_context
 from importlib.metadata import distributions
 from pathlib import Path
-import shutil
 from typing import (
     Any,
     Callable,
@@ -377,8 +377,8 @@ def _remove_stale_otel_sdk_packages():
             for d in otel_sdk_distributions:
                 if len(d.entry_points) == 0:
                     # Distribution appears to be empty.  Remove it
-                    logger.debug(f"Removing empty opentelemetry_sdk distribution at: {d._path}")
-                    shutil.rmtree(d._path)
+                    logger.debug(f"Removing empty opentelemetry_sdk distribution at: {d._path}")  # type: ignore
+                    shutil.rmtree(d._path)  # type: ignore
 
 
 def _setup_root_span_initializer(


### PR DESCRIPTION
## Issue
This hack mitigate an issue where the otel library's mechanism to discover resource detectors raised an Exception after a charm refresh, as described in https://github.com/canonical/grafana-agent-operator/issues/146.  That was caused by a juju/charmcraft issue (https://bugs.launchpad.net/juju/+bug/2058335) where, when upgrading packages, Juju leaves behind package metadata from the old versions.  This caused otel's discovery mechanism to incorrectly use the old resource detector, leading to an exception.

## Solution
The fix here is to, before the otel discovery mechanism fires, detect if we have multiple "opentelemetry_sdk" distributions (packages) and if we do, delete any that appear to be stale (where "stale" is determined by whether they present `entry_points` - this assumption worked in testing, but not sure if it is universally valid)

## Context
https://github.com/canonical/grafana-agent-operator/issues/146

## Testing Instructions
(in a machine model)

to repro the original issue
```
charmcraft pack
juju deploy grafana-agent --revision=134 --channel=latest/stable
juju deploy ubuntu
juju relate grafana-agent ubuntu
# wait for deploy to finish and charm to go to blocked (because it has no target for its metrics)

juju refresh grafana-agent --channel latest/edge
# charm should refresh and go to error
```

to demo the fix:

```
juju deploy grafana-agent --revision=134 --channel=latest/stable
juju deploy ubuntu
juju relate grafana-agent ubuntu
# wait for deploy to finish and charm to go to blocked (because it has no target for its metrics)

# rebuild grafana-agent latest/edge with this PR's version of the library
juju refresh grafana-agent --path ./grafana-agent_ubuntu-22.04-amd64.charm
# charm should refresh and go back to blocked.  It should not go to error
```

## Release Notes
Adds a workaround for [juju bug 2058335](https://bugs.launchpad.net/juju/+bug/2058335), which results in parts of old python packages being left in the virtual environment after upgrades during charm refresh.   This patch detects and removes any duplicate `opentelemetry-exporter-otlp-proto-http` package found during upgrade.