### PR TITLE
added test for autoinstrumentation on inherited methods

### DIFF
--- a/tests/scenario/test_charm_tracing.py
+++ b/tests/scenario/test_charm_tracing.py
@@ -592,4 +592,3 @@ def test_inheritance_tracing(caplog):
         ctx.run("start", State())
         spans = f.call_args_list[0].args[0]
         assert spans[0].name == "method call: SuperCharm.foo"
-


### PR DESCRIPTION
We didn't have tests for charm_tracing on inherited methods.
Now we do. 