### PR TITLE
Fix resume error

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -369,8 +369,9 @@ class TempoCharm(CharmBase):
 
     def _on_tempo_pebble_custom_notice(self, event: PebbleNoticeEvent):
         if event.notice.key == self.tempo.tempo_ready_notice_key:
+            # collect-unit-status should now report ready.
             logger.debug("pebble api reports ready")
-            # collect-unit-status should do the rest.
+
             try:
                 self.tempo.container.stop("tempo-ready")
             except APIError:

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -7,7 +7,7 @@ from charm import TempoCharm
 
 
 @pytest.fixture
-def tempo_charm(tmp_path):
+def tempo_charm():
     with patch("charm.KubernetesServicePatch"):
         with patch("lightkube.core.client.GenericSyncClient"):
             yield TempoCharm

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -7,7 +7,7 @@ from charm import TempoCharm
 
 
 @pytest.fixture
-def tempo_charm():
+def tempo_charm(tmp_path):
     with patch("charm.KubernetesServicePatch"):
         with patch("lightkube.core.client.GenericSyncClient"):
             yield TempoCharm

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -1,6 +1,5 @@
-import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 import yaml


### PR DESCRIPTION
On sleep/resume, the tempo charm goes into error because it receives a custom notice event for a service that doesn't exist in pebble (yet)?
Unclear what's causing this, but it's a pain.
Workaround and test included.