### PR TITLE
Add tempo-ready service for interface tests

### DIFF
--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -44,7 +44,7 @@ def interface_tester(interface_tester: InterfaceTester):
                                                 "startup": "enabled",
                                                 "current": "active",
                                                 "name": "tempo-ready",
-                                            }
+                                            },
                                         },
                                         "checks": {},
                                     }

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -39,6 +39,11 @@ def interface_tester(interface_tester: InterfaceTester):
                                                 "startup": "enabled",
                                                 "current": "active",
                                                 "name": "tempo",
+                                            },
+                                            "tempo-ready": {
+                                                "startup": "enabled",
+                                                "current": "active",
+                                                "name": "tempo-ready",
                                             }
                                         },
                                         "checks": {},

--- a/tests/interface/test_tracing.py
+++ b/tests/interface/test_tracing.py
@@ -3,14 +3,6 @@
 from interface_tester import InterfaceTester
 
 
-def test_tracing_v0_interface(interface_tester: InterfaceTester):
-    interface_tester.configure(
-        interface_name="tracing",
-        interface_version=0,
-    )
-    interface_tester.run()
-
-
 def test_tracing_v2_interface(interface_tester: InterfaceTester):
     interface_tester.configure(
         interface_name="tracing",


### PR DESCRIPTION
## Issue
Interface tests for `tracing` with tempo-k8s charm are failing with:

```
ERROR    pytest_interface_tester:plugin.py:330 Interface tester plugin failed with Uncaught exception (<class 'RuntimeError'>) in operator/charm code: RuntimeError('400 Bad Request: service "tempo-ready" does not exist')
```


## Solution
<!-- A summary of the solution addressing the above issue -->
Add tempo-ready service to conftest.py used by interface tests.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This change fixes only `tracing/v2` tests - previous versions fail due drop in support in #108. A separate PR to charm-relation-interfaces will follow, dropping support for previous tracing versions in tempo-k8s together with other test changes.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
