### PR TITLE
Add using `is_ready` safeguard to `get_endpoint` docstring

### DIFF
--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -906,7 +906,7 @@ class TracingEndpointRequirer(Object):
 
         It could happen that this function gets called before the provider publishes the endpoints.
         In such a scenario, if a non-leader unit calls this function, a permission denied exception will be raised due to
-        unauthorized access to the local app databag. To prevent this, this function needs to be guarded by the `is_ready` check.
+        restricted access. To prevent this, this function needs to be guarded by the `is_ready` check.
 
         Raises:
         ProtocolNotRequestedError:

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -107,7 +107,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["pydantic"]
 
@@ -902,7 +902,16 @@ class TracingEndpointRequirer(Object):
     def get_endpoint(
         self, protocol: ReceiverProtocol, relation: Optional[Relation] = None
     ) -> Optional[str]:
-        """Receiver endpoint for the given protocol."""
+        """Receiver endpoint for the given protocol.
+
+        It could happen that this function gets called before the provider publishes the endpoints.
+        In such a scenario, if a non-leader unit calls this function, a permission denied exception will be raised due to
+        unauthorized access to the local app databag. To prevent this, this function needs to be guarded by the `is_ready` check.
+
+        Raises:
+        ProtocolNotRequestedError:
+            If the charm unit is the leader unit and attempts to obtain an endpoint for a protocol it did not request.
+        """
         endpoint = self._get_endpoint(relation or self._relation, protocol=protocol)
         if not endpoint:
             requested_protocols = set()

--- a/tests/scenario/test_charm_tracing.py
+++ b/tests/scenario/test_charm_tracing.py
@@ -434,8 +434,10 @@ def test_tracing_requirer_remote_charm_no_request_no_response(leader, relation):
         relations = []
 
     # THEN self.tempo() will raise on init
+    # FIXME: non-leader units should get a permission denied exception,
+    # but it won't fire due to https://github.com/canonical/operator/issues/1378
     with pytest.raises(UncaughtCharmError, match=r"ProtocolNotRequestedError"):
-        ctx.run("start", State(relations=relations))
+        ctx.run("start", State(relations=relations, leader=leader))
 
 
 class MyRemoteBorkyCharm(CharmBase):

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ description = Run scenario tests
 deps =
     pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
     coverage[toml]
-    ops-scenario>=4.0.3
+    ops-scenario>=4.0.3,<7.0.0
     .[lib_pydeps]
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
## Issue
Fixes #169 

## Solution
Add documentation to use the `is_ready` safeguard before `get_endpoint` to prevent permission denied exceptions due to non-leader units trying to access local app databags.